### PR TITLE
Changed the website author link to linkedin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,9 +63,9 @@ author:
   avatar : "/assets/images/bio-photo.jpg"
   bio    : "DevOps Engineer writing about my experiments with #devops for fun."
   links:
-    - label: "Website"
-      icon: "fas fa-fw fa-link"
-      url: "https://"
+    - label: "LinkedIn"
+      icon: "fab fa-fw fa-linkedin"
+      url: "https://www.linkedin.com/in/athila"
     - label: "Twitter"
       icon: "fab fa-fw fa-twitter-square"
       url: "https://x.com/binarydevotee"


### PR DESCRIPTION
This pull request removes the `Website` author link in favor of `LinkedIn`